### PR TITLE
Fix run command in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Windows:
 ### 2.2 run a new Docker container
 Linux/MacOS:
 
-    $ docker run -p 8888:8888 -v /data:/notebooks -it--rm asashiho/ml-jupyterlab
+    $ docker run -p 8888:8888 -v /data:/notebooks -it --rm asashiho/ml-jupyterlab
 
 Windows:
 


### PR DESCRIPTION
Command wasn't running, due to no space between -it and --rm